### PR TITLE
Fix invalid length on UK codes

### DIFF
--- a/CountryValidator.Tests/CountriesValidators/UnitedKingdomValidatorTests.cs
+++ b/CountryValidator.Tests/CountriesValidators/UnitedKingdomValidatorTests.cs
@@ -32,6 +32,7 @@ namespace CountryValidation.Tests
         [Theory]
         [InlineData("980780684", true)]
         [InlineData("802311781", false)]
+        [InlineData("6640211", false)]
         public void TestCorrectEntityCode(string code, bool isValid)
         {
             Assert.Equal(isValid, _ukValidator.ValidateEntity(code).IsValid);

--- a/CountryValidator/CountriesValidators/UnitedKingdomValidator.cs
+++ b/CountryValidator/CountriesValidators/UnitedKingdomValidator.cs
@@ -103,6 +103,11 @@ namespace CountryValidation.Countries
                 return ValidationResult.Invalid("Invalid format. First digit cannot be 0");
             }
 
+            if (vatId.Length != 9)
+            {
+                return ValidationResult.Invalid("Invalid length");
+            }
+
             var no = long.Parse(vatId.Substring(0, 7));
 
             for (int i = 0; i < 7; i++)


### PR DESCRIPTION
Shorter codes were throwing exceptions rather than returning an invalid result