### PR TITLE
avoid throwing number parse exception

### DIFF
--- a/CountryValidator.Tests/CountriesValidators/NetherlandsValidatorTests.cs
+++ b/CountryValidator.Tests/CountriesValidators/NetherlandsValidatorTests.cs
@@ -27,6 +27,7 @@ namespace CountryValidation.Tests
         [InlineData("111222333", true)]
         [InlineData("941331490", true)]
         [InlineData("101222331", false)]
+        [InlineData("notanumber", false)]
         [InlineData("9413.31.490", true)]
         [InlineData("941331491", false)]
         public void TestIndividualCode(string code, bool isValid)

--- a/CountryValidator/CountriesValidators/NetherlandsValidator.cs
+++ b/CountryValidator/CountriesValidators/NetherlandsValidator.cs
@@ -51,7 +51,7 @@ namespace CountryValidation.Countries
         public override ValidationResult ValidateIndividualTaxCode(string number)
         {
             number = number.RemoveSpecialCharacthers();
-            if (!(number.All(char.IsDigit) || int.Parse(number) <= 0))
+            if (!(number.All(char.IsDigit) || !int.TryParse(number, out var parsedNum) || parsedNum <= 0 ))
             {
                 return ValidationResult.Invalid("Invalid format. Only digits are allowed");
             }


### PR DESCRIPTION
if test string is not a number validator is currently throwing a parse exception when ValidationResult.Invalid should be used instead

be aware that I did not check the whole solution for the same issue

this fix is for NL ValidateIndividualTaxCode only 