### PR TITLE
Update NorwayValidator : TIN ending with 00

### DIFF
--- a/CountryValidator/CountriesValidators/NorwayValidator.cs
+++ b/CountryValidator/CountriesValidators/NorwayValidator.cs
@@ -57,7 +57,7 @@ namespace CountryValidation.Countries
                 sum += weights[i] * (int)char.GetNumericValue(number[i]);
             }
 
-            return 11 - sum % 11;
+            return (11 - sum % 11) % 11;
         }
 
         private bool HasValidDate(string number)


### PR DESCRIPTION
Hi

Some Norwegian Tax Identification Number are marked as invalid even if they are valid. This happens when the number ends with "00".
Example : 
14087726100 is a valid Norwegian TIN number
If I apply CalculateChecksum for the first nine digits, I have : 
3 + 28 + 0 + 8 + 56 + 63 + 8 + 30 + 2 ==> sum = 198
sum % 11 = 0 (198/11 = 18, mod = 0)
Then, the function returns 11, which is obviously different from 0. By adding another % 11 operation, it solves the problem.
If the result of sum % 11 is less than 0, nothing changes. If the result is 11, it will return 11 % 11 => 0.

It works also for the second checksum :  
the digits multiplied by the weights are 5 + 16 + 0 + 16 + 49 + 42 + 10 + 24 + 3 + 0 ==> sum = 165
sum % 11 = 0 (165/11 = 15, mod = 0)