### PR TITLE
Fix IcelandValidator TaxCode validation error

### DIFF
--- a/CountryValidator/CountriesValidators/IcelandValidator.cs
+++ b/CountryValidator/CountriesValidators/IcelandValidator.cs
@@ -49,7 +49,7 @@ namespace CountryValidation.Countries
                 sum += (int)char.GetNumericValue(value[i]) * weight[i];
             }
             sum = 11 - sum % 11;
-            return sum == value[8] ? ValidationResult.Success() : ValidationResult.InvalidChecksum();
+            return sum == (int)char.GetNumericValue(value[8]) ? ValidationResult.Success() : ValidationResult.InvalidChecksum();
         }
 
 


### PR DESCRIPTION
Hi.
The test "sum == value[8]" always returns false as it's a comparison between integer and char, thus the function always returns ValidationResult.InvalidChecksum().
Adding a parsing to integer on value[8] resolves the problem.