### PR TITLE
Fixed Belgium validator where new VAT number starts with BE1xxxxxxxxx

### DIFF
--- a/CountryValidator.DataAnnotations/CountryValidator.DataAnnotations.csproj
+++ b/CountryValidator.DataAnnotations/CountryValidator.DataAnnotations.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net47;</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net48;</TargetFrameworks>
     <Description>DataAnnotations to validate VAT codes, social security numbers or tin numbers.</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>CountryValidator.png</PackageIcon>

--- a/CountryValidator.Tests/CountriesValidators/BelgiumValidatorTests.cs
+++ b/CountryValidator.Tests/CountriesValidators/BelgiumValidatorTests.cs
@@ -44,7 +44,8 @@ namespace CountryValidation.Tests
         [InlineData("BE403019261", true)]
         [InlineData("BE 428759497", true)]
         [InlineData("431150351", false)]
-        [InlineData("BE1000115332", true)]
+        [InlineData("BE1000003682", true)]
+        [InlineData("BE1000003681", false)]
         public void TestCorrectVatCode(string code, bool isValid)
         {
             Assert.Equal(isValid, _belgiumValidator.ValidateVAT(code).IsValid);

--- a/CountryValidator.Tests/CountriesValidators/BelgiumValidatorTests.cs
+++ b/CountryValidator.Tests/CountriesValidators/BelgiumValidatorTests.cs
@@ -44,6 +44,7 @@ namespace CountryValidation.Tests
         [InlineData("BE403019261", true)]
         [InlineData("BE 428759497", true)]
         [InlineData("431150351", false)]
+        [InlineData("BE1000115332", true)]
         public void TestCorrectVatCode(string code, bool isValid)
         {
             Assert.Equal(isValid, _belgiumValidator.ValidateVAT(code).IsValid);

--- a/CountryValidator.Tests/CountryValidator.Tests.csproj
+++ b/CountryValidator.Tests/CountryValidator.Tests.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
   </ItemGroup>

--- a/CountryValidator/CountriesValidators/BelgiumValidator.cs
+++ b/CountryValidator/CountriesValidators/BelgiumValidator.cs
@@ -66,7 +66,7 @@ namespace CountryValidation.Countries
                 id = id.PadLeft(10, '0');
             }
 
-            if (!Regex.IsMatch(id, @"^0?\d{9}$"))
+            if (!Regex.IsMatch(id, @"^[0-1]?\d{9}$"))
             {
                 return ValidationResult.InvalidFormat("1234567890");
             }

--- a/CountryValidator/CountryValidator.csproj
+++ b/CountryValidator/CountryValidator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Country Validator is a library that can be used to validate VAT/TVA codes, social security numbers and TINs (Tax Identification Numbers). All countries from European Union are supported and United States.</Description>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net47;</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net48;</TargetFrameworks>
     <Authors>Anghel Valentin</Authors>
     <RepositoryType>git</RepositoryType>
     <PackageTags>VAT, SSN, Id, Social Security Number, TIN, Countries Validator, Validator</PackageTags>
@@ -16,6 +16,7 @@
     <AssemblyVersion>1.1.0.3</AssemblyVersion>
     <FileVersion>1.1.0.3</FileVersion>
     <Version>1.1.3</Version>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- allowed Belgium VAT numbers to also start with 1
- added Unit Tests for VAT number belgium thatb start with 1
- updated to dot net 4.8 framework